### PR TITLE
mostly fix missing tile errors

### DIFF
--- a/lib/OpenLayers/Tile/Image.js
+++ b/lib/OpenLayers/Tile/Image.js
@@ -438,6 +438,7 @@ OpenLayers.Tile.Image = OpenLayers.Class(OpenLayers.Tile, {
                 this.setImgSrc(this.layer.getURL(this.bounds));
             } else {
                 OpenLayers.Element.addClass(img, "olImageLoadError");
+                this.setImgSrc(this.blankImageUrl);
                 this.events.triggerEvent("loaderror");
                 this.onImageLoad();
             }


### PR DESCRIPTION
Simplistic approach to fixing part of the missing tile errors.  This takes care of the case where the image is not reloaded, such as when adding a layer back to the map.  This does not fix the overall issue where the olImageError class is not properly added to all bad tiles' `<img/>` tags, but it does fix most visual errors except when the user clicks the zoom-out control very quickly.
