### PR TITLE
FIX: OpenLayers silently ignores textnode which exceed 4096 characters

### DIFF
--- a/lib/OpenLayers/Format/GML/Base.js
+++ b/lib/OpenLayers/Format/GML/Base.js
@@ -405,8 +405,8 @@ OpenLayers.Format.GML.Base = OpenLayers.Class(OpenLayers.Format.XML, {
                         name = "_typeName";
                     }
                 } else {
-                    // Assume attribute elements have one child node and that the child
-                    // is a text node.  Otherwise assume it is a geometry node.
+                    // Assume attribute elements have have only text nodes as children or no children.  
+                    // Otherwise assume it is a geometry node.
                     if (node.childNodes.length == 0 ||
                         node.childNodes.length >= 1 && node.firstChild.nodeType == 3) {
                             var isAttribute = this.extractAttributes;

--- a/lib/OpenLayers/Format/GML/Base.js
+++ b/lib/OpenLayers/Format/GML/Base.js
@@ -408,7 +408,7 @@ OpenLayers.Format.GML.Base = OpenLayers.Class(OpenLayers.Format.XML, {
                     // Assume attribute elements have one child node and that the child
                     // is a text node.  Otherwise assume it is a geometry node.
                     if(node.childNodes.length == 0 ||
-                       (node.firstChild.nodeType == 3)) {    
+                       (node.childNodes.length==1 && node.firstChild.nodeType == 3)) {    
                         if(this.extractAttributes) {
                             name = "_attribute";
                         }

--- a/lib/OpenLayers/Format/GML/Base.js
+++ b/lib/OpenLayers/Format/GML/Base.js
@@ -408,12 +408,24 @@ OpenLayers.Format.GML.Base = OpenLayers.Class(OpenLayers.Format.XML, {
                     // Assume attribute elements have one child node and that the child
                     // is a text node.  Otherwise assume it is a geometry node.
                     if(node.childNodes.length == 0 ||
-                       (node.childNodes.length == 1 && node.firstChild.nodeType == 3)) {
+                       (node.firstChild.nodeType == 3)) {    
                         if(this.extractAttributes) {
                             name = "_attribute";
                         }
                     } else {
-                        name = "_geometry";
+                        //check if all childNodes are text nodes. consider it attribute then.                                            
+                        var isAttribute=true;
+                        for (var i = node.childNodes.length - 1; i >= 0; i--) {
+                            if(node.childNodes[i].nodeType!=3){
+                                isAttribute=false;
+                                break;
+                            }
+                        }
+                        if(isAttribute === true && this.extractAttributes) {
+                            name = "_attribute";
+                        } else {
+                            name = "_geometry";    
+                        }                        
                     }
                 }
                 if(name) {
@@ -455,13 +467,6 @@ OpenLayers.Format.GML.Base = OpenLayers.Class(OpenLayers.Format.XML, {
                     this.geometryName = node.nodeName.split(":").pop();
                 }
                 this.readChildNodes(node, obj);
-                //Firefox (at least recent versions) includes a 4096 character limit per TextNode.
-                //Such nodes get treated as geometry and subsequently ignored silently.
-                //Such nodes are read as attributes.
-                //Issue #URL: https://github.com/openlayers/openlayers/issues/995
-                if(obj.attributes[this.geometryName]===undefined) {        
-                    this.readers.feature['_attribute'].apply(this, [node, obj]);         
-                }
             },
             "_attribute": function(node, obj) {
                 var local = node.localName || node.nodeName.split(":").pop();

--- a/lib/OpenLayers/Format/GML/Base.js
+++ b/lib/OpenLayers/Format/GML/Base.js
@@ -407,26 +407,20 @@ OpenLayers.Format.GML.Base = OpenLayers.Class(OpenLayers.Format.XML, {
                 } else {
                     // Assume attribute elements have one child node and that the child
                     // is a text node.  Otherwise assume it is a geometry node.
-                    if(node.childNodes.length == 0 ||
-                       (node.childNodes.length==1 && node.firstChild.nodeType == 3)) {    
-                        if(this.extractAttributes) {
-                            name = "_attribute";
-                        }
-                    } else {
-                        //check if all childNodes are text nodes. consider it attribute then.                                            
-                        var isAttribute=true;
-                        for (var i = node.childNodes.length - 1; i >= 0; i--) {
-                            if(node.childNodes[i].nodeType!=3){
-                                isAttribute=false;
-                                break;
+                    if (node.childNodes.length == 0 ||
+                        node.childNodes.length >= 1 && node.firstChild.nodeType == 3) {
+                            var isAttribute = this.extractAttributes;
+                            for (var i = node.childNodes.length - 1; isAttribute && i > 0 /* we already checked the first node */; i--) {
+                                isAttribute &= (node.childNodes[i].nodeType == 3)
                             }
-                        }
-                        if(isAttribute === true && this.extractAttributes) {
-                            name = "_attribute";
-                        } else {
-                            name = "_geometry";    
-                        }                        
+
+                            if (isAttribute) {
+                                name = "_attribute";
+                            }
                     }
+                    else {
+                        name = "_geometry";
+                    }                    
                 }
                 if(name) {
                     this.readers.feature[name].apply(this, [node, obj]);

--- a/lib/OpenLayers/Format/GML/Base.js
+++ b/lib/OpenLayers/Format/GML/Base.js
@@ -455,6 +455,13 @@ OpenLayers.Format.GML.Base = OpenLayers.Class(OpenLayers.Format.XML, {
                     this.geometryName = node.nodeName.split(":").pop();
                 }
                 this.readChildNodes(node, obj);
+                //Firefox (at least recent versions) includes a 4096 character limit per TextNode.
+                //Such nodes get treated as geometry and subsequently ignored silently.
+                //Such nodes are read as attributes.
+                //Issue #URL: https://github.com/openlayers/openlayers/issues/995
+                if(obj.attributes[this.geometryName]===undefined) {        
+                    this.readers.feature['_attribute'].apply(this, [node, obj]);         
+                }
             },
             "_attribute": function(node, obj) {
                 var local = node.localName || node.nodeName.split(":").pop();


### PR DESCRIPTION
Firefox (at least recent versions) includes a 4096 character limit per TextNode.
Such nodes get treated as geometry and subsequently ignored silently.
In my fix such nodes are read again as attributes.
Issue #URL: https://github.com/openlayers/openlayers/issues/995
